### PR TITLE
Make texts and lines larger

### DIFF
--- a/evals-analysis-app/app.R
+++ b/evals-analysis-app/app.R
@@ -6,7 +6,7 @@ library(tidyverse)
 library(gitlink)
 
 # Set the default theme for ggplot2 plots
-ggplot2::theme_set(ggplot2::theme_minimal())
+ggplot2::theme_set(ggplot2::theme_minimal(base_size = 22))
 
 # Apply the CSS used by the Shiny app to the ggplot2 plots
 thematic_shiny()
@@ -162,7 +162,7 @@ server <- function(input, output) {
   # Render line plot for conversions over time
   output$line <- renderPlot({
     ggplot(conversions(), aes(x = date, y = n, color = evaluation)) +
-      geom_line() +
+      geom_line(linewidth = 1) +
       theme(axis.title = element_blank()) +
       labs(color = "Trial Type")
   })


### PR DESCRIPTION
Very cool demo! The theme looks very slick! Wanted to make it a little bit nicer for you by making the chart texts larger. 

It's really just a one-liner (setting the `base_size` in `theme_minimal()` is one of my favorite tricks :D)